### PR TITLE
Support Dns endpoints in http cluster

### DIFF
--- a/src/cluster/DotNext.AspNetCore.Cluster/Net/Cluster/Consensus/Raft/Http/RaftClusterMember.cs
+++ b/src/cluster/DotNext.AspNetCore.Cluster/Net/Cluster/Consensus/Raft/Http/RaftClusterMember.cs
@@ -35,7 +35,6 @@ namespace DotNext.Net.Cluster.Consensus.Raft.Http
             this.context = context;
             status = new AtomicEnum<ClusterMemberStatus>(ClusterMemberStatus.Unknown);
             BaseAddress = remoteMember;
-            Endpoint = remoteMember.ToEndPoint() ?? throw new UriFormatException(ExceptionMessages.UnresolvedHostName(remoteMember.Host));
             DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(UserAgent, (GetType().Assembly.GetName().Version ?? new Version()).ToString()));
         }
 
@@ -162,7 +161,8 @@ namespace DotNext.Net.Cluster.Consensus.Raft.Http
             return metadata;
         }
 
-        public IPEndPoint Endpoint { get; }
+        public IPEndPoint Endpoint =>
+            BaseAddress.ToEndPoint() ?? throw new UriFormatException(ExceptionMessages.UnresolvedHostName(BaseAddress.Host));
 
         bool IClusterMember.IsLeader => context.IsLeader(this);
 

--- a/src/cluster/DotNext.AspNetCore.Cluster/Net/Network.cs
+++ b/src/cluster/DotNext.AspNetCore.Cluster/Net/Network.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using IServer = Microsoft.AspNetCore.Hosting.Server.IServer;
@@ -21,7 +22,7 @@ namespace DotNext.Net
                 case UriHostNameType.IPv6:
                     return new IPEndPoint(IPAddress.Parse(memberUri.Host), memberUri.Port);
                 case UriHostNameType.Dns:
-                    return memberUri.IsLoopback ? new IPEndPoint(IPAddress.Loopback, memberUri.Port) : null;
+                    return memberUri.IsLoopback ? new IPEndPoint(IPAddress.Loopback, memberUri.Port) : new IPEndPoint(Dns.GetHostAddresses(memberUri.Host).First(), memberUri.Port);
                 default:
                     return null;
             }


### PR DESCRIPTION
This is a simple proposed change that will support dns based member entries for RaftClusterMember

